### PR TITLE
override chunk hash for entry chunk (mainTemplate)

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -15,6 +15,10 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin("this-compilation", function(compilation) {
     var mainTemplate = compilation.mainTemplate;
+
+    // https://github.com/diurnalist/chunk-manifest-webpack-plugin/issues/7
+    mainTemplate.updateHashForChunk = mainTemplate.updateHash;
+
     mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
       var filename = this.outputOptions.filename;
       var chunkManifest;


### PR DESCRIPTION
The `mainTemplate` chunk hash includes the hashes of other chunks on the presumption that it contains the chunk manifest.

A monkey-patch of [`MainTemplate.updateHashForChunk()`](https://github.com/webpack/webpack/blob/master/lib/MainTemplate.js#L173) such that it does not call the `"hash-for-chunk"` extensibility point.

Proposed as solution for issue #7.