### PR TITLE
Update to use chunkhash filename

### DIFF
--- a/lib/ChunkManifestPlugin.js
+++ b/lib/ChunkManifestPlugin.js
@@ -16,7 +16,7 @@ ChunkManifestPlugin.prototype.apply = function(compiler) {
   compiler.plugin("this-compilation", function(compilation) {
     var mainTemplate = compilation.mainTemplate;
     mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
-      var filename = this.outputOptions.filename;
+      var filename = this.outputOptions.chunkFilename || this.outputOptions.filename;
       var chunkManifest;
 
       if (filename) {


### PR DESCRIPTION
If a webpack config specifies a `output.chunkFilename` it should be used over `output.filename`.