### PR TITLE
Mention webpack-md5-hash dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ module.exports = {
 };
 ```
 
+Currently this plugin is also dependent on the [webpack-md5-hash](https://github.com/erm0l0v/webpack-md5-hash) webpack plugin to work properly. Install that plugin as well (`npm install webpack-md5-hash`) and include it in your webpack plugins list (`new WebpackMd5Hash()`).
+
 ### Options
 
 #### `filename`


### PR DESCRIPTION
If a plugin requires another dependency to work, then this should be mentioned in the readme.

https://github.com/diurnalist/chunk-manifest-webpack-plugin/issues/7